### PR TITLE
Importer

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+from sqlalchemy import create_engine
+import os
+from subprocess import call
+
+def main():
+  global dbEngine
+  base_dir = "/home/ernesto/test/repotest/"
+  
+  # Cargar archivo con usario y contraseña para conectarse a la base de datos
+  fName = "mysql-credentials.txt"
+  if os.path.isfile(fName):
+    f = open(fName, "r")
+
+  if f:
+    dbUser = f.readline()
+    dbUser = dbUser.strip(" \n\r\t")
+    dbPassword = f.readline()
+    dbPassword = dbPassword.strip(" \n\r\t")
+
+  # Conectarse a la base de datos
+  dbEngine = create_engine("mysql://%s:%s@localhost/chiliproject" % (dbUser, dbPassword))
+  connection = dbEngine.connect()
+
+  #fsalida = open("salida.txt", "w")
+
+  # Ejecutar un query
+  projects = dbEngine.execute("select id, name, identifier, description from projects")
+
+  # obtener todos los proyectos
+  for project in projects:
+    #fsalida.write("Project name: %s\n" % project['name'])
+    #fsalida.write("Project description: %s\n" % project['description'])
+    #print_wikis(fsalida, project["id"])
+    #fsalida.write("\n-----------------------------------\n\n")
+    create_file_struct(base_dir, project["identifier"])
+
+  projects.close()
+  #fsalida.close()
+
+def print_wikis(fsalida, project_id):
+  # para cada proyecto, obtener sus wikis
+  wikis = dbEngine.execute("select id from wikis where project_id = %s" % project_id)
+  
+  for wiki in wikis:
+    # obtener las páginas que integran la wiki
+    wiki_pages = dbEngine.execute("select id, title from wiki_pages where wiki_id = %s" % wiki["id"])
+    
+    for page in wiki_pages:
+      fsalida.write("Wiki page title: %s\n" % page['title'])
+      # para cada página, obtener su contenido
+      contents = dbEngine.execute("select text from wiki_contents where page_id = %s" % page["id"])
+      for content in contents:
+        fsalida.write("%s\n" % content["text"])
+      contents.close()    
+    
+    wiki_pages.close()
+  
+  wikis.close()
+
+def create_file_struct(base_dir, project_name):
+  wiki_path = os.path.join(base_dir, project_name, "wiki")
+  src_path = os.path.join(base_dir, project_name, "src")
+  
+  if not os.path.exists(wiki_path):
+    os.makedirs(wiki_path)
+  if not os.path.exists(src_path):
+    os.makedirs(src_path)
+  
+  # iniciar el repo del wiki
+  call(["git", "init", wiki_path])
+  
+
+if __name__ == "__main__":
+    main()

--- a/importer.py
+++ b/importer.py
@@ -4,42 +4,42 @@ from sqlalchemy import create_engine
 import os
 from subprocess import call
 
+
 def main():
   global dbEngine
   base_dir = "/home/ernesto/test/repotest/"
   
-  # Cargar archivo con usario y contraseña para conectarse a la base de datos
+  # Cargar credenciales para la base de datos desde un archivo externo
   fName = "mysql-credentials.txt"
   if os.path.isfile(fName):
-    f = open(fName, "r")
+    credentialFile = open(fName, "r")
 
-  if f:
-    dbUser = f.readline()
+  if credentialFile:
+    dbUser = credentialFile.readline()
     dbUser = dbUser.strip(" \n\r\t")
-    dbPassword = f.readline()
+    dbPassword = credentialFile.readline()
     dbPassword = dbPassword.strip(" \n\r\t")
+    credentialFile.close()
 
   # Conectarse a la base de datos
   dbEngine = create_engine("mysql://%s:%s@localhost/chiliproject" % (dbUser, dbPassword))
   connection = dbEngine.connect()
 
-  #fsalida = open("salida.txt", "w")
+  # Cargar información de los proyectos
+  projects = dbEngine.execute("select id, name, identifier, description, is_public from projects")
 
-  # Ejecutar un query
-  projects = dbEngine.execute("select id, name, identifier, description from projects")
-
-  # obtener todos los proyectos
+  # Obtener todos los proyectos
   for project in projects:
-    #fsalida.write("Project name: %s\n" % project['name'])
-    #fsalida.write("Project description: %s\n" % project['description'])
-    #print_wikis(fsalida, project["id"])
-    #fsalida.write("\n-----------------------------------\n\n")
-    create_file_struct(base_dir, project["identifier"])
+    if project["is_public"]:
+      create_file_struct(os.path.join(base_dir, "public"), project["identifier"])
+    else:
+      create_file_struct(os.path.join(base_dir, "private"), project["identifier"])
 
   projects.close()
-  #fsalida.close()
 
-def print_wikis(fsalida, project_id):
+
+# generar todas las wikis para un proyecto
+def generate_wikis(wiki_base_path):
   # para cada proyecto, obtener sus wikis
   wikis = dbEngine.execute("select id from wikis where project_id = %s" % project_id)
   
@@ -48,6 +48,7 @@ def print_wikis(fsalida, project_id):
     wiki_pages = dbEngine.execute("select id, title from wiki_pages where wiki_id = %s" % wiki["id"])
     
     for page in wiki_pages:
+      wiki_file = open()
       fsalida.write("Wiki page title: %s\n" % page['title'])
       # para cada página, obtener su contenido
       contents = dbEngine.execute("select text from wiki_contents where page_id = %s" % page["id"])
@@ -59,18 +60,23 @@ def print_wikis(fsalida, project_id):
   
   wikis.close()
 
+
 def create_file_struct(base_dir, project_name):
   wiki_path = os.path.join(base_dir, project_name, "wiki")
   src_path = os.path.join(base_dir, project_name, "src")
   
+  # Crear las carpetas si es que no existen
   if not os.path.exists(wiki_path):
     os.makedirs(wiki_path)
   if not os.path.exists(src_path):
     os.makedirs(src_path)
   
-  # iniciar el repo del wiki
+  # Iniciar el repositorio de git para el wiki
   call(["git", "init", wiki_path])
-  
+
 
 if __name__ == "__main__":
-    main()
+  main()
+
+
+

--- a/test.py
+++ b/test.py
@@ -3,26 +3,58 @@
 from sqlalchemy import create_engine
 import os.path
 
-# Cargar archivo con usario y contraseña para conectarse a la base de datos
-fName = "mysql-credentials.txt"
-if os.path.isfile(fName):
-  f = open(fName, "r")
+def main():
+  global dbEngine
+  
+  # Cargar archivo con usario y contraseña para conectarse a la base de datos
+  fName = "mysql-credentials.txt"
+  if os.path.isfile(fName):
+    f = open(fName, "r")
 
-if f:
-  dbUser = f.readline()
-  dbUser = dbUser.strip(" \n\r\t")
-  dbPassword = f.readline()
-  dbPassword = dbPassword.strip(" \n\r\t")
+  if f:
+    dbUser = f.readline()
+    dbUser = dbUser.strip(" \n\r\t")
+    dbPassword = f.readline()
+    dbPassword = dbPassword.strip(" \n\r\t")
 
-# Conectarse a la base de datos
-dbEngine = create_engine("mysql://%s:%s@localhost/chiliproject" % (dbUser, dbPassword))
-connection = dbEngine.connect()
+  # Conectarse a la base de datos
+  dbEngine = create_engine("mysql://%s:%s@localhost/chiliproject" % (dbUser, dbPassword))
+  connection = dbEngine.connect()
 
-# Ejecutar un query
-result = dbEngine.execute("select title from wiki_pages")
+  fsalida = open("salida.txt", "w")
 
-for row in result:
-  print "Wiki page title:", row['title']
+  # Ejecutar un query
+  projects = dbEngine.execute("select id, name, description from projects")
 
-result.close()
+  # obtener todos los proyectos
+  for project in projects:
+    fsalida.write("Project name: %s\n" % project['name'])
+    fsalida.write("Project description: %s\n" % project['description'])
+    print_wikis(fsalida, project["id"])
+    fsalida.write("\n-----------------------------------\n\n")
 
+  projects.close()
+  fsalida.close()
+
+def print_wikis(fsalida, project_id):
+  # para cada proyecto, obtener sus wikis
+  wikis = dbEngine.execute("select id from wikis where project_id = %s" % project_id)
+  
+  for wiki in wikis:
+    # obtener las páginas que integran la wiki
+    wiki_pages = dbEngine.execute("select id, title from wiki_pages where wiki_id = %s" % wiki["id"])
+    
+    for page in wiki_pages:
+      fsalida.write("Wiki page title: %s\n" % page['title'])
+      # para cada página, obtener su contenido
+      contents = dbEngine.execute("select text from wiki_contents where page_id = %s" % page["id"])
+      for content in contents:
+        fsalida.write("%s\n" % content["text"])
+      contents.close()    
+    
+    wiki_pages.close()
+  
+  wikis.close()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Esta primera versión de **Importer** genera la estructura de carpetas y vuelca el contenido de los wikis por proyecto.
Jerarquía:

```
proyecto_raíz
 \--private
     \-- proyecto_1
          \-- wiki
          \-- src
 \-- public
         \-- proyecto_2
              \-- wiki
              \-- src
```
